### PR TITLE
Potential fix for code scanning alert no. 4: Uncontrolled data used in path expression

### DIFF
--- a/backend/routers/geo.py
+++ b/backend/routers/geo.py
@@ -1,10 +1,12 @@
 import json
+import re
 from pathlib import Path
 from fastapi import APIRouter, HTTPException
 
 route = APIRouter(prefix="/geo", tags=["geo"])
 
 DATA_DIR = Path("data/geo")
+SLUG_PATTERN = re.compile(r"^[a-z0-9]+(?:-[a-z0-9]+)*$")
 def _available_states() -> list[str]:
     """Return all state slugs that have a generated JSON file."""
     return sorted(
@@ -14,7 +16,17 @@ def _available_states() -> list[str]:
 
 
 def _load_state(slug: str) -> dict:
-    path = DATA_DIR / f"{slug}.json"
+    if not SLUG_PATTERN.fullmatch(slug):
+        raise HTTPException(status_code=400, detail="Invalid state slug format")
+
+    base_dir = DATA_DIR.resolve()
+    path = (base_dir / f"{slug}.json").resolve()
+
+    try:
+        path.relative_to(base_dir)
+    except ValueError:
+        raise HTTPException(status_code=400, detail="Invalid state path")
+
     if not path.exists():
         raise HTTPException(
             status_code=404,


### PR DESCRIPTION
Potential fix for [https://github.com/tasguard-solution/clarion_state_map/security/code-scanning/4](https://github.com/tasguard-solution/clarion_state_map/security/code-scanning/4)

General fix approach: never use user input directly in file paths without validation and containment checks. For this case, validate `slug` against a strict allow-list pattern (state slugs should be simple lowercase words/hyphen format), then resolve the final path and verify it remains under the trusted base directory.

Best fix in this file:
1. Add `import re`.
2. Define a compiled regex for allowed slugs, e.g. `^[a-z0-9]+(?:-[a-z0-9]+)*$`.
3. In `_load_state`, reject invalid slugs with `HTTPException(400, ...)`.
4. Resolve both `DATA_DIR` and candidate file path and ensure candidate is inside `DATA_DIR` using `relative_to` check.
5. Keep existing behavior for not found files (`404`) and JSON loading.

This preserves functionality (valid states still load) while preventing traversal and uncontrolled path usage.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
