### PR TITLE
PR Summary: Repo Restructure to Monorepo + Profile Dropdown

### DIFF
--- a/frontend/src/components/Navbar.css
+++ b/frontend/src/components/Navbar.css
@@ -146,3 +146,91 @@
   width: 24px;
   height: 24px;
 }
+
+/* Profile Dropdown Styles */
+.profile-container {
+  position: relative;
+  height: 100%;
+  display: flex;
+  align-items: center;
+}
+
+.profile-icon-wrapper.active {
+  background-color: var(--orange-button-bg-hover);
+  transform: translate(1px, 1px);
+  box-shadow: 1px 1px 0px var(--border-primary);
+}
+
+.profile-dropdown {
+  position: absolute;
+  top: calc(100% + 8px);
+  right: 0;
+  width: 200px;
+  background: var(--navbar-bg);
+  backdrop-filter: blur(12px);
+  -webkit-backdrop-filter: blur(12px);
+  border: 2px solid var(--border-primary);
+  border-radius: 8px;
+  box-shadow: 4px 4px 0px var(--border-primary);
+  z-index: 1000;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  animation: dropdownFadeIn 0.2s ease-out;
+}
+
+@keyframes dropdownFadeIn {
+  from {
+    opacity: 0;
+    transform: translateY(-10px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+.dropdown-header {
+  padding: 12px 16px;
+  background-color: rgba(0, 0, 0, 0.05);
+}
+
+.user-email {
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--text-primary);
+  word-break: break-all;
+  opacity: 0.8;
+}
+
+.dropdown-divider {
+  height: 2px;
+  background-color: var(--border-primary);
+}
+
+.dropdown-item {
+  padding: 10px 16px;
+  font-size: 14px;
+  color: var(--text-primary);
+  text-decoration: none;
+  background: none;
+  border: none;
+  text-align: left;
+  cursor: pointer;
+  transition: all 0.2s ease;
+  font-family: inherit;
+  font-weight: 500;
+}
+
+.dropdown-item:hover {
+  background-color: var(--navbar-bg-hover);
+  padding-left: 20px;
+}
+
+.dropdown-item.sign-out {
+  color: #ff4d4d;
+}
+
+.dropdown-item.sign-out:hover {
+  background-color: rgba(255, 77, 77, 0.1);
+}

--- a/frontend/src/components/Navbar.tsx
+++ b/frontend/src/components/Navbar.tsx
@@ -6,7 +6,7 @@ import { Link } from "react-router-dom";
 import SearchBar from "./navbar/SearchBar";
 import Logo from "./navbar/Logo";
 import Carousel from "./navbar/Carousel";
-import { useState, useEffect } from "react";
+import { useState, useEffect, useRef } from "react";
 import { supabase } from "../lib/supabase";
 import profileIcon from "../assets/Profile by Rizky Studio.svg";
 
@@ -20,6 +20,8 @@ function Navbar() {
   /////////////////////////////////////////
   // This code snippet shows how to change something on user sign in or sign out
   const [session, setSession] = useState<any>(null);
+  const [dropdownOpen, setDropdownOpen] = useState(false);
+  const dropdownRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
     const handleSync = async (currentSession: any) => {
@@ -43,10 +45,7 @@ function Navbar() {
 
     supabase.auth.getSession().then(async ({ data: { session } }) => {
       if (session) {
-        // Double-check with the server to ensure the user still actually exists
-        // (Handles the edge case where a user was manually deleted from the database)
         const { data: { user }, error } = await supabase.auth.getUser();
-        
         if (error || !user) {
           await supabase.auth.signOut();
           handleSync(null);
@@ -58,17 +57,31 @@ function Navbar() {
       }
     });
 
-    const {
-      data: { subscription },
-    } = supabase.auth.onAuthStateChange((_event, session) => {
+    const { data: { subscription } } = supabase.auth.onAuthStateChange((_event, session) => {
       handleSync(session);
     });
 
     return () => subscription.unsubscribe();
   }, []);
 
-  // This code snippet shows how to change something on user sign in or sign out
-  /////////////////////////////////////////
+  // Handle clicking outside the dropdown
+  useEffect(() => {
+    function handleClickOutside(event: MouseEvent) {
+      if (dropdownRef.current && !dropdownRef.current.contains(event.target as Node)) {
+        setDropdownOpen(false);
+      }
+    }
+    document.addEventListener("mousedown", handleClickOutside);
+    return () => document.removeEventListener("mousedown", handleClickOutside);
+  }, []);
+
+  const handleSignOut = async () => {
+    const { error } = await supabase.auth.signOut();
+    if (error) {
+      console.error("Error signing out:", error.message);
+    }
+    setDropdownOpen(false);
+  };
 
   return (
     <nav id="navbar">
@@ -86,8 +99,32 @@ function Navbar() {
           <aside className="right-menu">
             <SearchBar />
             {session ? (
-              <div className="profile-icon-wrapper">
-                <img src={profileIcon} alt="Profile" className="profile-icon" />
+              <div className="profile-container" ref={dropdownRef}>
+                <div 
+                  className={`profile-icon-wrapper ${dropdownOpen ? 'active' : ''}`}
+                  onClick={() => setDropdownOpen(!dropdownOpen)}
+                >
+                  <img src={profileIcon} alt="Profile" className="profile-icon" />
+                </div>
+                
+                {dropdownOpen && (
+                  <div className="profile-dropdown">
+                    <div className="dropdown-header">
+                      <span className="user-email">{session.user.email}</span>
+                    </div>
+                    <div className="dropdown-divider"></div>
+                    <Link to="/profile" className="dropdown-item" onClick={() => setDropdownOpen(false)}>
+                      Profile
+                    </Link>
+                    <Link to="/settings" className="dropdown-item" onClick={() => setDropdownOpen(false)}>
+                      Settings
+                    </Link>
+                    <div className="dropdown-divider"></div>
+                    <button className="dropdown-item sign-out" onClick={handleSignOut}>
+                      Sign Out
+                    </button>
+                  </div>
+                )}
               </div>
             ) : (
               <CustomButton text="Sign Up" href="/signup" />
@@ -100,3 +137,4 @@ function Navbar() {
 }
 
 export default Navbar;
+


### PR DESCRIPTION
### Overview
Converts the project into a monorepo by registering the existing backend as a Git submodule, commits all pre-generated geographic and election data assets, deletes now-redundant generator/scaffold files, and ships a working profile dropdown in the frontend Navbar.

---

### Changes

**Monorepo / Submodule Setup**
- `.gitmodules` *(new)* — Registers `backend` as a Git submodule pointing to `https://github.com/tasguard-solution/data_lorry_backend`.
- `backend` *(submodule pointer)* — Pinned to commit `7af44e9`.

**Deleted Backend Files (now live in the submodule repo)**
- `backend/auth.py` — Supabase JWKS JWT verification + FastAPI `get_current_user` dependency.
- `backend/database.py` — SQLAlchemy Postgres engine + `get_db` dependency.
- `backend/models.py` — `ProfilePublic` and `ProfilePrivate` ORM models.
- `backend/schemas.py` — Pydantic schemas: `PublicProfile`, `ProfileResponse`, `ProfileCreate`, `ProfileUpdate`.
- `backend/main.py` — FastAPI app with auto-router discovery, CORS config, and startup migration.
- `backend/requirements.txt` — Base dependencies (`fastapi`, `uvicorn`).
- `backend/routers/election.py` — `/election` endpoints (nation / state / LGA vote totals from `LGALevelResult.csv`).
- `backend/routers/geo.py` — `/geo` endpoints (state list, nation shapes, per-state LGA SVG paths).
- `backend/routers/users.py` — `/api/users/sync` and `/api/users/me` endpoints.
- `backend/routers/__init__.py` — Empty init.
- `backend/generators/election.py` — One-off script that downloaded election CSVs from GitHub.
- `backend/generators/geo.py` — GeoJSON fetcher + equirectangular SVG projection generator.
- `backend/generators/__init__.py` — Empty init.
- `backend/start.sh` — Procfile startup script (ran generators + uvicorn).
- `backend/Procfile` — `web: bash start.sh`.
- `backend/test.py` — Ad-hoc pandas test script.
- `backend/README.md` — Old GIS service readme.
- `backend/MAP_EXTRACTION_GUIDE.md` — SVG extraction guide.

**Committed Data Assets** *(previously generated at deploy-time, now static)*
- `backend/data/geo/*.json` — Per-state LGA SVG path files for all 36 states + FCT.
- `backend/data/geo/_geojson_cache.json` — Cached raw GeoJSON from qedsoftware.
- `backend/data/geo/nigeria-lgas.json` — Full Nigeria LGA GeoJSON.
- `backend/data/nigeria/states.json` — National-level state shapes.
- `backend/data/election/` — All election CSVs: `LGALevelResult.csv`, `AllPollingUnitsInfo.csv`, `stamp_sig_missing.csv`, `voter_info.csv`, archive CSVs (1999–2022 presidential + gubernatorial), `README.md`.
- `backend/data/NBS_DATA/ch02–ch19_*.csv` — NBS/NDHS survey data (housing, health, fertility, nutrition, HIV, domestic violence, FGM, NCDs, etc.).
- `backend/data/election/nigeria_election_data.json`

**Frontend — Navbar Profile Dropdown** (`frontend/src/components/`)
- `Navbar.tsx` — Profile icon is now clickable, toggling a dropdown. Dropdown shows the signed-in user's email, links to `/profile` and `/settings`, and a **Sign Out** button. Click-outside detection via `useRef` + `mousedown` listener closes the dropdown automatically. `handleSignOut` calls `supabase.auth.signOut()` and collapses the menu.
- `Navbar.css` — New styles for `.profile-container`, `.profile-dropdown`, `.dropdown-header`, `.dropdown-item`, `.dropdown-divider`, `.user-email`, `.sign-out`, and a `dropdownFadeIn` slide animation.

---

### Affected Files
- `.gitmodules` *(new)*
- `backend` *(submodule)*
- `backend/data/geo/*.json` *(new — 37 state files + cache)*
- `backend/data/nigeria/states.json` *(new)*
- `backend/data/election/*.csv` + `archive/*.csv` *(new)*
- `backend/data/NBS_DATA/ch02–ch19_*.csv` *(new)*
- `backend/auth.py`, `database.py`, `models.py`, `schemas.py`, `main.py`, `requirements.txt`, `start.sh`, `Procfile`, `test.py`, `README.md`, `MAP_EXTRACTION_GUIDE.md` *(deleted)*
- `backend/generators/election.py`, `geo.py`, `__init__.py` *(deleted)*
- `backend/routers/election.py`, `geo.py`, `users.py`, `__init__.py` *(deleted)*
- `frontend/src/components/Navbar.tsx` *(modified)*
- `frontend/src/components/Navbar.css` *(modified)*

---

### Design Decisions / Notes
- **Submodule vs. copy** — The backend is a submodule (not copied), so changes to the backend repo stay independent and are pulled in by updating the submodule pointer. Make sure CI/CD clones with `--recurse-submodules`.
- **Static data over runtime generation** — Committing all geo and election data eliminates the network-dependent generator scripts from the deploy path. Trade-off: the repo is larger, but deploys are faster and more reliable.
- **NBS data committed** — The 18 NDHS/NBS CSV chapters suggest upcoming data features (health, demographics). These are large files; consider Git LFS if the repo grows.
- **Dropdown closes on outside click** — Uses `mousedown` (not `click`) to ensure the outside-click fires before any inner button's `onClick`, preventing race conditions.

---

### Testing Suggestions
- Clone with `git clone --recurse-submodules` and verify the backend submodule initialises at the correct commit.
- Sign in on the frontend and confirm the profile dropdown opens, displays the correct email, and closes on outside click.
- Click **Sign Out** and verify the session is cleared and the UI reverts to the Sign Up button.
- Navigate to `/profile` and `/settings` from the dropdown and verify the links resolve (or 404 gracefully if not yet built).
- Check Railway deploy logs confirm geo/election data is found without triggering the generator scripts.

---

### Related Issues
- Closes #— (Navbar profile dropdown)
- Closes #— (Monorepo / submodule restructure)